### PR TITLE
stored prefix and message_index to camel case

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,14 +9,17 @@ import json
 # TODO: Make bot a class like normal bots.
 client = discord.Client()
 
+#bot prefix
+PREFIX = '!'
+
 # A dictionary of basic things for the bot to return. More complex (i.e.
 # data-driven) interactions aren't stored here, those go below.
-message_index = {
-    '!ping': 'Pong!',
-    '!hello': 'World!',
+messageIndex = {
+    Prefix + 'ping': 'Pong!',
+    Prefix + 'hello': 'World!',
     'rickroll': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
     'xcq': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-    '!balloumoji': ':bigdissapointment::moustache::ballouminatti::1982::nope::notapproved::fedora1::happy::flowers::notbad::soundboard:',
+    Prefix + 'balloumoji': ':bigdissapointment::moustache::ballouminatti::1982::nope::notapproved::fedora1::happy::flowers::notbad::soundboard:',
     'it\'s time to stop': 'https://www.youtube.com/watch?v=2k0SmqbBIpQ',
     'stop': 'https://www.youtube.com/watch?v=2k0SmqbBIpQ'
 }
@@ -38,9 +41,9 @@ async def on_message(message):
     # Only send back message if user that sent the triggering message isn't a bot
     if not message.author.bot:
         # Special returns!
-        if msg.startswith('!about'):
+        if msg.startswith(PREFIX + 'about'):
             await client.send_message(message.channel, 'Victibot is a chatbot for Team 1418\'s Discord server. Bot is currently running as ' + client.user.name + ' (ID ' + client.user.id + '). View on GitHub: https://github.com/ErikBoesen/victibot')
-        elif msg.startswith('!xkcd'):
+        elif msg.startswith(PREFIX + 'xkcd'):
             # Store the number/other content after the '!xkcd '.
             comic = msg[6:]
 
@@ -49,7 +52,7 @@ async def on_message(message):
 
             # Send the URL of the image from the JSON fetched above.
             await client.send_message(message.channel, r.json()['img'])
-        elif msg == '!update':
+        elif msg == (PREFIX + 'update'):
             # Confirm that the bot is updating
             await client.send_message(message.channel, 'Updating...')
             # Start a git pull to update bot
@@ -59,7 +62,7 @@ async def on_message(message):
             # TODO: Apparently 'await' has been replaced in py3 with 'yield from'.
             # Implement this change.
             try:
-                await client.send_message(message.channel, message_index[msg])
+                await client.send_message(message.channel, messageIndex[msg])
             except:
                 pass
 

--- a/bot.py
+++ b/bot.py
@@ -15,11 +15,11 @@ PREFIX = '!'
 # A dictionary of basic things for the bot to return. More complex (i.e.
 # data-driven) interactions aren't stored here, those go below.
 messageIndex = {
-    Prefix + 'ping': 'Pong!',
-    Prefix + 'hello': 'World!',
+    PREFIX + 'ping': 'Pong!',
+    PREFIX + 'hello': 'World!',
     'rickroll': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
     'xcq': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-    Prefix + 'balloumoji': ':bigdissapointment::moustache::ballouminatti::1982::nope::notapproved::fedora1::happy::flowers::notbad::soundboard:',
+    PREFIX + 'balloumoji': ':bigdissapointment::moustache::ballouminatti::1982::nope::notapproved::fedora1::happy::flowers::notbad::soundboard:',
     'it\'s time to stop': 'https://www.youtube.com/watch?v=2k0SmqbBIpQ',
     'stop': 'https://www.youtube.com/watch?v=2k0SmqbBIpQ'
 }


### PR DESCRIPTION
For discord bots, its better practice to store the prefix into a data storage such as a variable, file, or database, as then you can update the prefix the whole bot from one source.  Also, its cleaner code to use camel case rather than underscores